### PR TITLE
Added populate-docker-aws-vpc and README update for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,32 @@ cf enable-service-access <service_name>
 
 ### Deploy on AWS VPC
 
-Change and target the `deployments/docker-aws-vpc.yml` to deploy it into a VPC.
+Assuming you used [terraform-aws-cf-install](https://github.com/cloudfoundry-community/terraform-aws-cf-install), ssh onto the Bastion server and run:
+```
+cd ~/workspace/deployments
+git clone https://github.com/cloudfoundry-community/docker-services-boshworkspace.git
+cd docker-services-boshworkspace
+```
+
+There is a helper script in `shell/populate-docker-aws-vpc` which will extract information from the cf-boshworkspace deployment on the bastion server and populate the variables in `deployments/docker-aws-vpc.yml`, a copy of the original file will be left in `deployments/docker-aws-vpc.yml.orig`.  Run the following on the bastion server:
+```
+cd ~/workspace/deployments/docker-services-boshworkspace/shell
+./populate-docker-aws-vpc
+```
+
+You will still need to modify the SUBNET_ID in `deployments/docker-aws-vpc.yml`.  In AWS Console navigate to VPC > Subnets and select a subnet named "docker", the subnet id will be in the format "subnet-xxxxxxxx" and replace the value SUBNET_ID in the file
+
+Your deployment manifest is now populated, launch the deployment from the bastion server:
+```
+cd ~/workspace/deployments/docker-services-boshworkspace
+bosh deployment docker-aws-vpc
+bosh prepare deployment
+bosh -n deploy
+```
 
 By default, it assumes you are deploying into a `10.10.5.0/24` subnet. This is an optimization for users of [terraform-aws-cf-install](https://github.com/cloudfoundry-community/terraform-aws-cf-install) which creates this subnet for us.
 
+#### Alternate Network Configurations
 If you want to deploy into another subnet CIDR, then add a `meta.subnets` to your deployment file to look something like:
 
 ```yaml

--- a/shell/populate-docker-aws-vpc
+++ b/shell/populate-docker-aws-vpc
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+assure_string_in_file() {
+  assurefilename=$1
+  assuresearchString=$2
+  assurereplaceString=$3
+
+  if grep -q "$assuresearchString" "$assurefilename"; then
+    re="s#^.*$assuresearchString.*#$assurereplaceString#"
+    sed -i "${re}" "$assurefilename"
+    (( "$?" == "0" )) ||
+    echo "Could not execute execute sed command replace $assuresearchString with $assurereplaceString in file $assurefilename, terminating install."
+  else
+    echo "$assurereplaceString" >> "$assurefilename"
+    (("$?" == "0")) ||
+    echo "Unable to set $assuresearchString in $assurefilename, terminating install."
+  fi
+}
+
+DIRECTOR_UUID=$(cat ~/workspace/deployments/cf-boshworkspace/deployments/cf-aws-tiny.yml | grep director_uuid | awk '{print $2}')
+SECURITY_GROUP_ACCESSIBLE_BY_CF_RUNNERS=$(cat ~/workspace/deployments/cf-boshworkspace/deployments/cf-aws-tiny.yml | grep security_groups  | awk '{print $2}')
+NATS_IP=$(cat ~/workspace/deployments/cf-boshworkspace/.deployments/cf-aws-tiny.yml | grep address | head -1 | awk '{print $2}')
+DOMAIN=$(cat ~/workspace/deployments/cf-boshworkspace/deployments/cf-aws-tiny.yml | grep " domain"  | awk '{print $2}')
+EXTERNAL_HOST="cf-container-broker.${DOMAIN}"
+CC_API_URL="http://api.${DOMAIN}"
+
+echo "DIRECTOR_UUID:                            ${DIRECTOR_UUID}"
+echo "CC_API_URL:                               ${CC_API_URL}"
+echo "EXTERNAL_HOST:                            ${EXTERNAL_HOST}"
+echo "NATS_IP:                                  ${NATS_IP}"
+echo "SUBNET_ID:                                Get this from AWS Console > VPC > Subnets > 'docker'"
+echo "SECURITY_GROUP_ACCESSIBLE_BY_CF_RUNNERS:  ${SECURITY_GROUP_ACCESSIBLE_BY_CF_RUNNERS}"
+
+filename="/home/ubuntu/workspace/deployments/docker-services-boshworkspace/deployments/docker-aws-vpc.yml"
+cp "${filename}" "${filename}.orig"
+assure_string_in_file $filename "director_uuid: DIRECTOR_UUID"                   "director_uuid: ${DIRECTOR_UUID}"
+assure_string_in_file $filename "    cc_api_uri: CC_API_URL"                     "    cc_api_uri: ${CC_API_URL}"
+assure_string_in_file $filename "    external_host: EXTERNAL_HOST"               "    external_host: ${EXTERNAL_HOST}"
+assure_string_in_file $filename "      - 10.10.3.10"                             "      - ${NATS_IP}"
+assure_string_in_file $filename "    - SECURITY_GROUP_ACCESSIBLE_BY_CF_RUNNERS"  "    - ${SECURITY_GROUP_ACCESSIBLE_BY_CF_RUNNERS}"
+
+echo "*********"
+echo "$filename has been updated, remember to update the SUBNET_ID"


### PR DESCRIPTION
Created a small bash script to extract values from the cf-boshworkspace run on the bastion server and update the docker-aws-vpc.yml file.  Still need to pull the SUBNET_ID for docker from the AWS Console, this doesn't appear to be stored on the bastion server's deployment manifests.  Updated the README to reflect usage of the script and methodology for deployment.