### PR TITLE
Start consul in server mode

### DIFF
--- a/templates/docker-properties.yml
+++ b/templates/docker-properties.yml
@@ -656,6 +656,7 @@ properties:
           - id: '2cb83bb4-2df9-11e4-a506-a6c5e4d22fb7'
             name: 'free'
             container:
+              command: '-server -bootstrap'
               backend: 'docker'
               image: 'progrium/consul'
               tag: 'latest'


### PR DESCRIPTION
Start consul in server mode as described [here](https://github.com/progrium/docker-consul#just-trying-out-consul)

Currently running `curl http://{docker_host_ip}:{consul_instance_port}/v1/status/peers` will retrun:
`No known Consul server`