### PR TITLE
Offline docker images

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,25 +7,26 @@ GEM
     aws-sdk-v1 (1.60.2)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    blobstore_client (1.2941.0)
+    blobstore_client (1.3069.0)
       aws-sdk (= 1.60.2)
-      bosh_common (~> 1.2941.0)
-      fog (~> 1.27.0)
+      bosh_common (~> 1.3069.0)
+      fog (~> 1.31.0)
+      fog-aws (<= 0.1.1)
       httpclient (= 2.4.0)
       multi_json (~> 1.1)
-      ruby-atmos-pure (~> 1.0.5)
-    bosh-template (1.2941.0)
+    bosh-template (1.3069.0)
       semi_semantic (~> 1.1.0)
-    bosh-workspace (0.8.5)
-      bosh_cli (>= 1.2682.0)
-      bosh_common (>= 1.2682.0)
-      git (~> 1.2.6)
+    bosh-workspace (0.9.1)
+      bosh_cli (>= 1.2905.0)
+      bosh_common (>= 1.2905.0)
+      hashdiff (~> 0.2.1)
       membrane (~> 1.1.0)
+      rugged (~> 0.23.0b3)
       semi_semantic (~> 1.1.0)
-    bosh_cli (1.2941.0)
-      blobstore_client (~> 1.2941.0)
-      bosh-template (~> 1.2941.0)
-      bosh_common (~> 1.2941.0)
+    bosh_cli (1.3069.0)
+      blobstore_client (~> 1.3069.0)
+      bosh-template (~> 1.3069.0)
+      bosh_common (~> 1.3069.0)
       cf-uaa-lib (~> 3.2.1)
       highline (~> 1.6.2)
       httpclient (= 2.4.0)
@@ -37,24 +38,28 @@ GEM
       netaddr (~> 1.5.0)
       progressbar (~> 0.9.0)
       terminal-table (~> 1.4.3)
-    bosh_common (1.2941.0)
+    bosh_common (1.3069.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.1.0)
     builder (3.2.2)
-    cf-uaa-lib (3.2.1)
+    cf-uaa-lib (3.2.3)
       multi_json
-    excon (0.45.3)
+    excon (0.45.4)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.27.0)
+    fog (1.31.0)
       fog-atmos
       fog-aws (~> 0.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.3)
+      fog-core (~> 1.30)
       fog-ecloud
+      fog-google (>= 0.0.2)
       fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
+      fog-riakcs
       fog-sakuracloud (>= 0.0.4)
       fog-serverlove
       fog-softlayer
@@ -68,29 +73,39 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.2)
+    fog-aws (0.1.1)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.7.1)
+    fog-brightbox (0.9.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.30.0)
+    fog-core (1.32.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.1.1)
+    fog-ecloud (0.3.0)
       fog-core
       fog-xml
-    fog-json (1.0.1)
+    fog-google (0.0.7)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
       fog-core (~> 1.0)
-      multi_json (~> 1.0)
-    fog-profitbricks (0.0.2)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
       fog-core
       fog-xml
       nokogiri
@@ -98,13 +113,17 @@ GEM
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
-    fog-sakuracloud (1.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.1.1)
       fog-core
       fog-json
     fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-softlayer (0.4.5)
+    fog-softlayer (0.4.7)
       fog-core
       fog-json
     fog-storm_on_demand (0.1.1)
@@ -123,23 +142,22 @@ GEM
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    git (1.2.7)
+    hashdiff (0.2.2)
     highline (1.6.21)
     httpclient (2.4.0)
     inflecto (0.0.2)
     ipaddress (0.8.0)
-    json (1.8.2)
+    json (1.8.3)
     json_pure (1.8.2)
-    little-plugger (1.1.3)
-    log4r (1.1.10)
+    little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
     membrane (1.1.0)
-    mime-types (2.5)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitar (0.5.4)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -149,10 +167,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     progressbar (0.9.2)
-    ruby-atmos-pure (1.0.5)
-      log4r (>= 1.1.9)
-      ruby-hmac (>= 0.4.0)
-    ruby-hmac (0.4.0)
+    rugged (0.23.2)
     semi_semantic (1.1.0)
     terminal-table (1.4.5)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ bosh -n deploy
 
 By default, it assumes you are deploying into a `10.10.5.0/24` subnet. This is an optimization for users of [terraform-aws-cf-install](https://github.com/cloudfoundry-community/terraform-aws-cf-install) which creates this subnet for us.
 
+#### Swarm & Offline images
+There are alternative deployment files for using docker with swarm.
+If you want to install the docker service broker without internet access be sure to checkout the offline deployments.
+Which use the [docker-broker-images-boshrelease](https://github.com/cloudfoundry-community/docker-broker-images-boshrelease) for installing the docker images.
+
 #### Alternate Network Configurations
 If you want to deploy into another subnet CIDR, then add a `meta.subnets` to your deployment file to look something like:
 

--- a/deployments/docker-offline-warden.yml
+++ b/deployments/docker-offline-warden.yml
@@ -1,0 +1,36 @@
+---
+name: docker-offline-warden
+director_uuid: current
+
+releases:
+  - name: docker-broker-images
+    version: 1
+    git: https://github.com/cloudfoundry-community/docker-broker-images-boshrelease
+
+  - name: docker
+    version: 16
+    git: https://github.com/cf-platform-eng/docker-boshrelease.git
+
+stemcells:
+  - name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+    version: 389
+
+templates:
+  - docker-deployment.yml
+  - docker-properties.yml
+  - docker-offline.yml
+  - docker-jobs.yml
+  - docker-warden.yml
+  
+meta:
+  cf_api_uri: "https://api.10.244.0.34.xip.io"
+  broker:
+    host: "cf-containers-broker.10.244.0.34.xip.io"
+    username: 'containers'
+    password: 'containers'
+  nats:
+    user: nats
+    password: nats
+    port: 4222
+    machines:
+      - 10.244.0.6

--- a/deployments/docker-swarm-offline-warden.yml
+++ b/deployments/docker-swarm-offline-warden.yml
@@ -1,0 +1,36 @@
+---
+name: docker-swarm-offline-warden
+director_uuid: current
+
+releases:
+  - name: docker-broker-images
+    version: latest
+    git: https://github.com/cloudfoundry-community/docker-broker-images-boshrelease
+    
+  - name: docker
+    version: 16
+    git: https://github.com/cf-platform-eng/docker-boshrelease.git
+
+stemcells:
+  - name: bosh-warden-boshlite-ubuntu-trusty-go_agent
+    version: 389
+
+templates:
+  - docker-deployment.yml
+  - docker-properties.yml
+  - docker-offline.yml
+  - docker-swarm-jobs.yml
+  - docker-warden.yml
+  
+meta:
+  cf_api_uri: "https://api.10.244.0.34.xip.io"
+  broker:
+    host: "cf-containers-broker.10.244.0.34.xip.io"
+    username: 'containers'
+    password: 'containers'
+  nats:
+    user: nats
+    password: nats
+    port: 4222
+    machines:
+      - 10.244.0.6

--- a/deployments/docker-warden.yml
+++ b/deployments/docker-warden.yml
@@ -14,7 +14,7 @@ stemcells:
 templates:
   - docker-deployment.yml
   - docker-properties.yml
-  - docker-swarm-jobs.yml
+  - docker-jobs.yml
   - docker-warden.yml
   
 meta:

--- a/templates/docker-jobs.yml
+++ b/templates/docker-jobs.yml
@@ -4,9 +4,13 @@ jobs:
   - name: docker
     templates:
       - name: docker
+        release: docker
       - name: cf-containers-broker
+        release: docker
     instances: 1
     resource_pool: default
     persistent_disk: 65536
     networks:
       - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(1, 2, 3, 4, 5) ))

--- a/templates/docker-offline.yml
+++ b/templates/docker-offline.yml
@@ -1,0 +1,1 @@
+../.releases/docker-broker-images/templates/docker-offline.yml

--- a/templates/docker-properties.yml
+++ b/templates/docker-properties.yml
@@ -14,6 +14,7 @@ properties:
   docker: ~
   swarm_manager: ~
   fetch_containers: ~
+  docker_broker_images: ~
   nats: (( meta.nats ))
   env:
     https_proxy: (( meta.https_proxy ))

--- a/templates/docker-swarm-jobs.yml
+++ b/templates/docker-swarm-jobs.yml
@@ -8,6 +8,7 @@ jobs:
   - name: docker
     templates:
       - name: docker
+        release: docker
     instances: (( meta.instances.docker ))
     resource_pool: default
     persistent_disk: 65536
@@ -19,7 +20,9 @@ jobs:
   - name: broker
     templates:
       - name: swarm_manager
+        release: docker
       - name: cf-containers-broker
+        release: docker
     instances: 1
     resource_pool: default
     persistent_disk: 2048
@@ -31,6 +34,7 @@ jobs:
   - name: fetch-containers
     templates:
       - name: fetch-containers
+        release: docker
     instances: 1
     resource_pool: default
     lifecycle: errand
@@ -44,7 +48,7 @@ properties:
 
   broker:
     fetch_images: false # use `bosh run errand fetch-containers` so broker is not blocked
-    docker_url: (( "http://" jobs.broker.networks.default.static_ips.[0] ":" swarm_manager.port ))
+    docker_url: (( "tcp://" jobs.broker.networks.default.static_ips.[0] ":" swarm_manager.port ))
     max_containers: 28000 # http://git.io/vGJkh
 
   fetch_containers:


### PR DESCRIPTION
Support colocating the [docker-broker-images-boshrelease](https://github.com/cloudfoundry-community/docker-broker-images-boshrelease). Which allows deployment without internet access (it packages the required docker images).